### PR TITLE
Create about screen

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,6 +9,7 @@
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
+    "react-icons": "^3.10.0",
     "react-redux": "^7.2.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",

--- a/demo/src/screens/AboutScreen/AboutScreen.css
+++ b/demo/src/screens/AboutScreen/AboutScreen.css
@@ -1,0 +1,3 @@
+.about-container {
+  margin : 10px 40px;
+}

--- a/demo/src/screens/AboutScreen/AboutScreen.js
+++ b/demo/src/screens/AboutScreen/AboutScreen.js
@@ -13,7 +13,7 @@ const /** JSX */ DESCRIPTION = <p>{'This page is a sample ecommerce ' +
   'a button press, click the '}<GoQuestion size={16}/>
 {' icon next to the button. This will bring up code samples for both the '}
 <a href={'https://developers.google.com/gtagjs'}>{'gtag.js '}</a>
-{'library and the TODO:NAME_THIS library. ' +
+{'library and the measure library. ' +
   'In addition to showing sample code, this site sends real data to Google ' +
   'Analytics. To inspect the hits, just open up the developer ' +
   'tools or use the '}
@@ -22,7 +22,7 @@ const /** JSX */ DESCRIPTION = <p>{'This page is a sample ecommerce ' +
   {'Google Analytics Debugger. '}</a>
 {'The full code for this site can be found in the demo folder of the '}
 <a href={'https://github.com/googleinterns/measurement-library'}>
-  {'github for the TODO:NAME_THIS library. '}</a>
+  {'github for the measure library. '}</a>
 {'If you are not a developer, but are simply interested in purchasing ' +
 'prints of the cat Poe, we regret to inform you that, as this is just a demo ' +
 'site, you will need to find another website selling pictures of Poe.'}

--- a/demo/src/screens/AboutScreen/AboutScreen.js
+++ b/demo/src/screens/AboutScreen/AboutScreen.js
@@ -2,30 +2,29 @@ import React from 'react';
 import {GoQuestion} from 'react-icons/go';
 import './AboutScreen.css';
 
-const /** JSX */ DESCRIPTION = <p>{'This page is a sample ecommerce ' +
-'application with a complete implementation of '}
+const /** !JSX */ DESCRIPTION = <p>This page is a sample ecommerce
+application with a complete implementation of
 <a href={'https://support.google.com/analytics/answer/6014841'}>
-  {'Enhanced Ecommerce.'}</a>
-{' Use this demo to understand how the Enhanced ' +
-  'Ecommerce code works, and what is required to implement it on your own ' +
-  'site. Every action in this demo comes with code samples showing ' +
-  'exactly how the feature is implemented. To view code associated with ' +
-  'a button press, click the '}<GoQuestion size={16}/>
-{' icon next to the button. This will bring up code samples for both the '}
-<a href={'https://developers.google.com/gtagjs'}>{'gtag.js '}</a>
-{'library and the measure library. ' +
-  'In addition to showing sample code, this site sends real data to Google ' +
-  'Analytics. To inspect the hits, just open up the developer ' +
-  'tools or use the '}
-<a
-  href={'https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna'}>
-  {'Google Analytics Debugger. '}</a>
-{'The full code for this site can be found in the demo folder of the '}
+  {' Enhanced Ecommerce. '}</a>
+Use this demo to understand how the Enhanced
+Ecommerce code works, and what is required to implement it on your own
+site. Every action in this demo comes with code samples showing
+exactly how the feature is implemented. To view code associated with
+a button press, click the <GoQuestion size={16}/>{' '}
+icon next to the button. This will bring up code samples for both the
+<a href={'https://developers.google.com/gtagjs'}>{' gtag.js '}</a>
+library and the measure library.
+In addition to showing sample code, this site sends real data to Google
+Analytics. To inspect the hits, just open up the developer
+tools or use the
+<a href={'https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna'}>
+  {' Google Analytics Debugger. '}</a>
+The full code for this site can be found in the demo folder of the
 <a href={'https://github.com/googleinterns/measurement-library'}>
-  {'github for the measure library. '}</a>
-{'If you are not a developer, but are simply interested in purchasing ' +
-'prints of the cat Poe, we regret to inform you that, as this is just a demo ' +
-'site, you will need to find another website selling pictures of Poe.'}
+  {' github for the measure library. '}</a>
+If you are not a developer, but are simply interested in purchasing
+prints of the cat Poe, we regret to inform you that, as this is just a demo
+site, you will need to find another website selling pictures of Poe.
 </p>;
 
 /**

--- a/demo/src/screens/AboutScreen/AboutScreen.js
+++ b/demo/src/screens/AboutScreen/AboutScreen.js
@@ -1,12 +1,41 @@
 import React from 'react';
+import {GoQuestion} from 'react-icons/go';
+import './AboutScreen.css';
+
+const /** JSX */ DESCRIPTION = <p>{'This page is a sample ecommerce ' +
+'application with a complete implementation of '}
+<a href={'https://support.google.com/analytics/answer/6014841'}>
+  {'Enhanced Ecommerce.'}</a>
+{' Use this demo to understand how the Enhanced ' +
+  'Ecommerce code works, and what is required to implement it on your own ' +
+  'site. Every action in this demo comes with code samples showing ' +
+  'exactly how the feature is implemented. To view code associated with ' +
+  'a button press, click the '}<GoQuestion size={16}/>
+{' icon next to the button. This will bring up code samples for both the '}
+<a href={'https://developers.google.com/gtagjs'}>{'gtag.js '}</a>
+{'library and the TODO:NAME_THIS library. ' +
+  'In addition to showing sample code, this site sends real data to Google ' +
+  'Analytics. To inspect the hits, just open up the developer ' +
+  'tools or use the '}
+<a
+  href={'https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna'}>
+  {'Google Analytics Debugger. '}</a>
+{'The full code for this site can be found in the demo folder of the '}
+<a href={'https://github.com/googleinterns/measurement-library'}>
+  {'github for the TODO:NAME_THIS library. '}</a>
+{'If you are not a developer, but are simply interested in purchasing ' +
+'prints of the cat Poe, we regret to inform you that, as this is just a demo ' +
+'site, you will need to find another website selling pictures of Poe.'}
+</p>;
 
 /**
  * @return {!JSX} Page component where describe our website.
  */
 export function AboutScreen() {
   return (
-    <div>
-      <h1>{`I'm the About Page!`}</h1>
+    <div className={'about-container'}>
+      <h1>{`About this site`}</h1>
+      {DESCRIPTION}
     </div>
   );
 }

--- a/demo/src/screens/ProductScreen/ProductScreen.js
+++ b/demo/src/screens/ProductScreen/ProductScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Container, Row, Col, Image, Button} from 'react-bootstrap';
-import blackDemo from '../../images/black.png';
+import blackDemo from '../../images/airplane_ears.png';
 
 /**
  * @return {!JSX} Page component for where a user can view

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -8778,6 +8778,13 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
+react-icons@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.10.0.tgz#6c217a2dde2e8fa8d293210023914b123f317297"
+  integrity sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-is@^16.12.0, react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
Users in the site may be a bit confused as to what it is for. The about screen clarifies this and provides some resources. Mostly copied from https://ga-dev-tools.appspot.com/enhanced-ecommerce/. 

![Screenshot 2020-06-16 at 5 56 47 PM](https://user-images.githubusercontent.com/19393086/84832169-c630e780-affa-11ea-9df4-eaab2fda1b0b.png)

(Also changed a line of code in the product screen that referenced to a non-existing file)