### PR TITLE
Split checkout screen to add billing information component

### DIFF
--- a/demo/src/components/BillingInfoForm/BillingInfoForm.js
+++ b/demo/src/components/BillingInfoForm/BillingInfoForm.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import {Form} from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import {makeFormGroup} from '../UserInfoForm/UserInfoForm.js';
+
+const /** !JSX */ cardType = makeFormGroup(/** label= */ 'Credit Card Type',
+    /** control= */ <Form.Control as="select" custom>
+      <option>Mastercard</option>
+      <option>Visa</option>
+      <option>American Express</option>
+      <option>Discover</option>
+    </Form.Control>,
+);
+
+const /** !JSX */ cardNumber = makeFormGroup(/** label= */ 'Credit Card Type',
+    /** control= */ <Form.Control type='number' required
+      defaultValue='4111111111111111'
+      placeholder='Credit Card Number (required)'
+    />,
+);
+
+const /** !JSX */ zipAndCode = <Form.Row>
+  {makeFormGroup(/** label= */'Security Code',
+      /** control= */ <Form.Control type='number' required
+        defaultValue='111'
+        placeholder='Security Code (required)'
+      />, /** useWholeRow= */ false)}
+  {makeFormGroup(/** label= */ 'Zip Code',
+      /** control= */ <Form.Control
+        type='number'
+        defaultValue='19123'
+        placeholder='Zip (optional)'
+      />, /** useWholeRow= */ false)}
+</Form.Row>;
+
+/**
+ * Creates a page component with a form to get billing information.
+ * @return {!JSX} The component.
+ */
+export function BillingInfoForm({formId}) {
+  return (
+    <Form id={formId}>
+      {cardType}
+      {cardNumber}
+      {zipAndCode}
+    </Form>
+  );
+}
+
+BillingInfoForm.propTypes = {
+  formId: PropTypes.string,
+};

--- a/demo/src/components/UserInfoForm/UserInfoForm.js
+++ b/demo/src/components/UserInfoForm/UserInfoForm.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  *      column by itself.
  * @returns {!JSX} A form group with the given label and control.
  */
-export const makeFormGroup = (label, control, useWholeRow=true) => {
+export const makeFormGroup = (label, control, useWholeRow = true) => {
   return (
     <Form.Group as={useWholeRow ? 'div' : Col}>
       <Form.Label>{label}</Form.Label>

--- a/demo/src/components/UserInfoForm/UserInfoForm.js
+++ b/demo/src/components/UserInfoForm/UserInfoForm.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  *      column by itself.
  * @returns {!JSX} A form group with the given label and control.
  */
-const makeFormGroup = (label, control, useWholeRow=true) => {
+export const makeFormGroup = (label, control, useWholeRow=true) => {
   return (
     <Form.Group as={useWholeRow ? 'div' : Col}>
       <Form.Label>{label}</Form.Label>

--- a/demo/src/screens/CheckoutScreen/CheckoutScreen.js
+++ b/demo/src/screens/CheckoutScreen/CheckoutScreen.js
@@ -1,15 +1,22 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Container, Col, Row, Button} from 'react-bootstrap';
 import {UserInfoForm} from '../../components/UserInfoForm/UserInfoForm.js';
 import {useHistory} from 'react-router-dom';
 import './CheckoutScreen.css';
 import {MiniCart} from '../../components/MiniCart/MiniCart.js';
+import {BillingInfoForm} from '../../components/BillingInfoForm/BillingInfoForm.js';
 
 /**
- * The ID for the form the user will fill out on this page.
+ * The ID for the personal info form the user will fill out on this page.
  * @const {string}
  */
-const FORM_ID = 'user-info-form';
+const USER_FORM_ID = 'user-info-form';
+
+/**
+ * The ID for the billing info form the user will fill out on this page.
+ * @const {string}
+ */
+const BILLING_FORM_ID = 'billing-info-form';
 
 /**
  * Page component for a user to enter in personal billing information
@@ -17,21 +24,45 @@ const FORM_ID = 'user-info-form';
  * @return {!JSX}
  */
 export function CheckoutScreen() {
+  const [shippingDone, setShippingDone] = useState(false);
   const /** !Object */ history = useHistory();
 
+  /**
+   * If the personal information the user has put in is valid,
+   * display the billing information form.
+   * Otherwise, alert the user that their form is invalid.
+   */
+  function continueIfPersonalValid() {
+    const form = document.getElementById(USER_FORM_ID);
+    if (form.checkValidity()) {
+      // navigate to thank you page with react-router
+      setShippingDone(true);
+    } else {
+      form.reportValidity();
+    }
+  }
   /**
    * Navigate to the thank you page iff the user info form is valid.
    * Otherwise, alert the user that the form is invalid.
    */
   function navIfFormValid() {
-    const form = document.getElementById(FORM_ID);
-    if (form.checkValidity()) {
+    const formPersonal = document.getElementById(USER_FORM_ID);
+    const formBilling = document.getElementById(BILLING_FORM_ID);
+    if (formBilling.checkValidity() && formPersonal.checkValidity()) {
       // navigate to thank you page with react-router
       history.push('/thanks');
     } else {
-      form.reportValidity();
+      formPersonal.reportValidity();
+      formBilling.reportValidity();
     }
   }
+  const userInfoSubmit =
+      <Button onClick={continueIfPersonalValid}>Submit Order</Button>;
+
+  const billingForm = (<>
+    <BillingInfoForm formId={BILLING_FORM_ID}/>
+    <Button onClick={navIfFormValid}>Submit Order</Button>
+  </>);
 
   return (
     <Container>
@@ -41,14 +72,14 @@ export function CheckoutScreen() {
       </Row>
       <Row className='checkout-content'>
         <Col xs={12} md={6}>
-          <UserInfoForm formId={FORM_ID}/>
+          <UserInfoForm formId={USER_FORM_ID}/>
         </Col>
         <Col xs={12} className='hide-medium-or-bigger checkout-header'>
           Your order
         </Col>
         <Col xs={12} md={6}>
           <MiniCart/>
-          <Button onClick={navIfFormValid}>Submit Order</Button>
+          {shippingDone ? billingForm : userInfoSubmit}
         </Col>
       </Row>
     </Container>

--- a/demo/src/screens/CheckoutScreen/CheckoutScreen.js
+++ b/demo/src/screens/CheckoutScreen/CheckoutScreen.js
@@ -4,6 +4,7 @@ import {UserInfoForm} from '../../components/UserInfoForm/UserInfoForm.js';
 import {useHistory} from 'react-router-dom';
 import './CheckoutScreen.css';
 import {MiniCart} from '../../components/MiniCart/MiniCart.js';
+// eslint-disable-next-line max-len
 import {BillingInfoForm} from '../../components/BillingInfoForm/BillingInfoForm.js';
 
 /**
@@ -35,15 +36,16 @@ export function CheckoutScreen() {
   function continueIfPersonalValid() {
     const form = document.getElementById(USER_FORM_ID);
     if (form.checkValidity()) {
-      // navigate to thank you page with react-router
       setShippingDone(true);
     } else {
       form.reportValidity();
     }
   }
+
   /**
-   * Navigate to the thank you page iff the user info form is valid.
-   * Otherwise, alert the user that the form is invalid.
+   * Navigate to the thank you page iff the user info form and
+   * billing forms are valid.
+   * Otherwise, alert the user of invalid form fields
    */
   function navIfFormValid() {
     const formPersonal = document.getElementById(USER_FORM_ID);
@@ -56,12 +58,12 @@ export function CheckoutScreen() {
       formBilling.reportValidity();
     }
   }
-  const userInfoSubmit =
-      <Button onClick={continueIfPersonalValid}>Submit Order</Button>;
 
+  const submitUserInfoButton =
+      <Button onClick={continueIfPersonalValid}>Continue</Button>;
   const billingForm = (<>
     <BillingInfoForm formId={BILLING_FORM_ID}/>
-    <Button onClick={navIfFormValid}>Submit Order</Button>
+    <Button onClick={navIfFormValid}>Confirm order</Button>
   </>);
 
   return (
@@ -79,7 +81,7 @@ export function CheckoutScreen() {
         </Col>
         <Col xs={12} md={6}>
           <MiniCart/>
-          {shippingDone ? billingForm : userInfoSubmit}
+          {shippingDone ? billingForm : submitUserInfoButton}
         </Col>
       </Row>
     </Container>


### PR DESCRIPTION
This PR adds forms to ask the user for their billing information, which appear on the checkout page after user information is submitted. This will allow for us to send more analytics events.

![Screenshot 2020-06-17 at 2 51 56 PM](https://user-images.githubusercontent.com/19393086/84937659-1e72f280-b0aa-11ea-8b35-3e437fb77557.png)
![Screenshot 2020-06-17 at 2 51 41 PM](https://user-images.githubusercontent.com/19393086/84937660-1f0b8900-b0aa-11ea-838d-7fd7464a19f0.png)
