### PR TITLE
Deploy app to the world wide web

### DIFF
--- a/demo/.gcloudignore
+++ b/demo/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/demo/README.md
+++ b/demo/README.md
@@ -4,8 +4,7 @@ The demo website to show features of the measure library.
 This site fires actual gtag and measure library events, and
 displays the code for them.
 
-[To run the site, click here!](https://measurement-library.wl.r.appspot.com/)
-
+[To run the site, click here!](http://measurement-library.appspot.com/)
 
 # Deploying the app locally
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,31 @@
+# Demo Website
+
+The demo website to show features of the measure library.
+This site fires actual gtag and measure library events, and
+displays the code for them.
+
+[To run the site, click here!](https://measurement-library.wl.r.appspot.com/)
+
+
+# Deploying the app locally
+
+To run the app locally, navigate to this /demo directory,
+then type the following commands in the console.
+
+```shell script
+yarn build
+yarn start
+```
+
+For a faster startup without building any files,
+you can run the command
+
+```shell script
+yarn qstart
+```
+
+(You can replace yarn with npm in any of the above commands
+if you would prefer.)
+
+Then, navigate to localhost:3000 to run the app.
+

--- a/demo/app.yaml
+++ b/demo/app.yaml
@@ -1,0 +1,1 @@
+runtime: nodejs10

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,10 +2,12 @@
   "name": "demo",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
+    "express": "^4.17.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.1",
     "react-dom": "^16.13.1",
@@ -15,7 +17,8 @@
     "redux": "^4.0.5"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "node server.js",
+    "qstart": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/demo/package.json
+++ b/demo/package.json
@@ -2,7 +2,6 @@
   "name": "demo",
   "version": "0.1.0",
   "private": true,
-  "proxy": "http://localhost:8080",
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,0 +1,17 @@
+const express = require('express');
+const app = express();
+const path = require('path');
+
+// Serve the static files from the React app
+app.use(express.static(path.join(__dirname, 'build')));
+
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname+'/build/index.html'));
+});
+
+// Listen to the App Engine-specified port, or 3000 otherwise
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}...`);
+});

--- a/demo/src/screens/ProductScreen/ProductScreen.js
+++ b/demo/src/screens/ProductScreen/ProductScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Container, Row, Col, Image, Button} from 'react-bootstrap';
-import blackDemo from '../../images/airplane_ears.png';
+import blackDemo from '../../images/black.png';
 
 /**
  * @return {!JSX} Page component for where a user can view

--- a/demo/src/screens/ProductScreen/ProductScreen.js
+++ b/demo/src/screens/ProductScreen/ProductScreen.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Container, Row, Col, Image, Button} from 'react-bootstrap';
-import blackDemo from '../../images/black.png';
+import blackDemo from '../../images/airplane_ears.png';
 
 /**
  * @return {!JSX} Page component for where a user can view


### PR DESCRIPTION
I set up the demo folder so that we can easily deploy it to google app engine in the future. One noteworthy change for @kjgalvan  @pedrosilva0111 is that react start now runs the build directly, so you have to call yarn build before running yarn start. I also added a command yarn qstart that does the same thing as yarn start used to do. This behavior is documented in the readme. 

I deployed the current version of the site here: http://measurement-library.appspot.com/

Deployment instructions for future reference:
First, download gcloud at https://cloud.google.com/sdk/docs and open the measurement-library project from your corp account (you have to choose out of like 1500). Next, navigate to the demo folder of measurement library and run yarn build, then gcloud app deploy. Then you can go to the site, or run gloud app browse to see it.

EDIT: Looking into editing this commit so as not to break yarn start by request of KJ