### PR TITLE
Add code modals to carousel

### DIFF
--- a/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.css
+++ b/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.css
@@ -2,18 +2,33 @@
   text-shadow: 2px 3px 5px rgba(0,0,0,0.5);
 }
 
-.carousel-caption a {
+.carousel-caption a,
+.carousel-caption .btn-link {
   color: white;
   text-decoration: underline;
 }
 
-.carousel-caption a:hover {
+.carousel-caption .btn-link {
+  padding: .2rem .4rem;
+}
+
+.carousel-caption a:hover,
+.carousel-caption .btn-link:hover {
   color: lightgray;
 }
 
 @media (min-width: 40em) {
   .carousel-caption h3 {
     font-size: 2.5rem;
+  }
+
+  .carousel-caption .btn-link {
+    padding: .375rem .75rem;
+  }
+
+  .carousel-header svg {
+    height: 1.5rem;
+    width: 1.5rem;
   }
 
   .carousel-caption p,
@@ -27,9 +42,19 @@
     font-size: 3rem;
   }
 
+  .carousel-header svg {
+    height: 2rem;
+    width: 2rem;
+  }
+
   .carousel-caption p,
   .carousel-caption a {
     font-size: 2rem;
+  }
+
+  .carousel-text svg {
+    height: 1.5rem;
+    width: 1.5rem;
   }
 }
 
@@ -47,5 +72,15 @@
 @media (min-width: 110em) {
   .carousel-caption h3 {
     font-size: 4rem;
+  }
+
+  .carousel-header svg {
+    height: 2.5rem;
+    width: 2.5rem;
+  }
+
+  .carousel-text svg {
+    height: 2rem;
+    width: 2rem;
   }
 }

--- a/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
+++ b/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
@@ -30,7 +30,6 @@ export function HomeCarousel() {
         promotion_name: 'Home Carousel',
       },
     ],
-    promotion_name: 'Home Carousel',
   };
 
   // Send view_promotion event when the carousel loads for the first time.

--- a/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
+++ b/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
@@ -111,7 +111,7 @@ export function HomeCarousel() {
         <Carousel.Caption>
           <div className="header-with-modal carousel-header">
             <h3>
-              Stunning High Quality Prints Available
+              {`Stunning High Quality Prints Available`}
               {carouselCodeModal}
             </h3>
           </div>
@@ -123,7 +123,7 @@ export function HomeCarousel() {
                 }}
                 to="/product/7ba94"
               >
-              latest piece
+                {`latest piece`}
               </Link>
             </p>
             {getSelectPromotionCodeModal('7ba94')}
@@ -139,7 +139,7 @@ export function HomeCarousel() {
         <Carousel.Caption>
           <div className="header-with-modal carousel-header">
             <h3>
-              SALE!
+              {`SALE!`}
             </h3>
             {carouselCodeModal}
           </div>
@@ -151,7 +151,7 @@ export function HomeCarousel() {
                 }}
                 to="/product/hjdf7"
               >
-              View Deal
+                {`View Deal`}
               </Link>
             </p>
             {getSelectPromotionCodeModal('hjdf7', 25)}
@@ -167,7 +167,7 @@ export function HomeCarousel() {
         <Carousel.Caption>
           <div className="header-with-modal carousel-header">
             <h3 className="font-italic">
-              Toe Beans
+              {`Toe Beans`}
             </h3>
             {carouselCodeModal}
           </div>
@@ -180,7 +180,7 @@ export function HomeCarousel() {
                 }}
                 to="/product/3h488"
               >
-                Buy Now
+                {`Buy Now`}
               </Link>
             </p>
             {getSelectPromotionCodeModal('3h488')}

--- a/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
+++ b/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
@@ -5,7 +5,8 @@ import slideOne from '../../../images/slide_one.jpg';
 import slideTwo from '../../../images/slide_two.jpg';
 import slideThree from '../../../images/slide_three.jpg';
 import {event} from '../../../lib/gtag.js';
-import {getItemParameters} from '../../../utils.js';
+import {CodeModal} from '../../../components/CodeModal/CodeModal.js';
+import {getItemParameters, getEventCodeSnippet, getMeasureCodeSnippet} from '../../../utils.js';
 import './HomeCarousel.css';
 
 /**
@@ -13,36 +14,50 @@ import './HomeCarousel.css';
  * @return {!JSX}
  */
 export function HomeCarousel() {
+  const viewPromotionParameters = {
+    items: [
+      {
+        ...getItemParameters('7ba94'),
+        promotion_name: 'Home Carousel',
+      },
+      {
+        ...getItemParameters('hjdf7'),
+        promotion_name: 'Home Carousel',
+        discount: 25,
+      },
+      {
+        ...getItemParameters('3h488'),
+        promotion_name: 'Home Carousel',
+      },
+    ],
+    promotion_name: 'Home Carousel',
+  };
+
   // Send view_promotion event when the carousel loads for the first time.
   useEffect(() => {
-    event('view_promotion', {
-      items: [
-        {
-          ...getItemParameters('7ba94'),
-          promotion_name: 'Home Carousel',
-        },
-        {
-          ...getItemParameters('hjdf7'),
-          promotion_name: 'Home Carousel',
-          discount: 25,
-        },
-        {
-          ...getItemParameters('3h488'),
-          promotion_name: 'Home Carousel',
-        },
-      ],
-      promotion_name: 'Home Carousel',
-    });
+    event('view_promotion', viewPromotionParameters);
   }, []);
 
+  const carouselCodeModal =
+      <CodeModal
+        popupId="view_promotion"
+        gtagCode={
+          getEventCodeSnippet('view_promotion', viewPromotionParameters)
+        }
+        measureCode={getMeasureCodeSnippet()}
+      />;
+
   /**
-   * Send select_promotion event to Google Analytics when a carousel
-   * slide promotional item is selected.
+   * Collects a single promotional item's standard parameters and
+   * returns it as an object with items attribute mapped to
+   * the items array containing a single promotional item.
    * @param {string} itemId
    * @param {number=} discount Price discount of item (if any)
+   * @return {{items: Array<!ItemParameters>}} An object containing
+   *     an items attibute mapped to an array of {@link ItemParameters}
    */
-  function onSlideClick(itemId, discount = 0) {
-    event('select_promotion', {
+  function getSelectPromotionParameters(itemId, discount = 0) {
+    return {
       items: [
         {
           ...getItemParameters(itemId),
@@ -51,7 +66,39 @@ export function HomeCarousel() {
           ...(discount > 0 && {discount}),
         },
       ],
-    });
+    };
+  }
+
+  /**
+   * Send select_promotion event to Google Analytics when a carousel
+   * slide promotional item is selected.
+   * @param {string} itemId
+   * @param {number=} discount Price discount of item (if any)
+   */
+  function onSlideClick(itemId, discount = 0) {
+    event('select_promotion', getSelectPromotionParameters(itemId, discount));
+  }
+
+  /**
+   * Creates a select_promotion event code modal with code snippets
+   * for gtag and measure libraries.
+   * @param {string} itemId
+   * @param {number=} discount Price discount of item (if any)
+   * @return {!JSX} Code snippet of the event.
+   */
+  function getSelectPromotionCodeModal(itemId, discount = 0) {
+    return (
+      <CodeModal
+        popupId="view_promotion"
+        gtagCode={
+          getEventCodeSnippet(
+              'select_promotion',
+              getSelectPromotionParameters(itemId, discount),
+          )
+        }
+        measureCode={getMeasureCodeSnippet()}
+      />
+    );
   }
 
   return (
@@ -63,17 +110,25 @@ export function HomeCarousel() {
           alt="First slide"
         />
         <Carousel.Caption>
-          <h3>Stunning High Quality Prints Available</h3>
-          <p>{`View our `}
-            <Link
-              onClick={() => {
-                onSlideClick('7ba94');
-              }}
-              to="/product/7ba94"
-            >
+          <div className="header-with-modal carousel-header">
+            <h3>
+              Stunning High Quality Prints Available
+              {carouselCodeModal}
+            </h3>
+          </div>
+          <div className="header-with-modal carousel-text">
+            <p>{`View our `}
+              <Link
+                onClick={() => {
+                  onSlideClick('7ba94');
+                }}
+                to="/product/7ba94"
+              >
               latest piece
-            </Link>.
-          </p>
+              </Link>
+            </p>
+            {getSelectPromotionCodeModal('7ba94')}
+          </div>
         </Carousel.Caption>
       </Carousel.Item>
       <Carousel.Item>
@@ -83,17 +138,25 @@ export function HomeCarousel() {
           alt="Third slide"
         />
         <Carousel.Caption>
-          <h3>SALE!</h3>
-          <p>{`Get this classic 50% off. `}
-            <Link
-              onClick={() => {
-                onSlideClick('hjdf7', 25);
-              }}
-              to="/product/hjdf7"
-            >
+          <div className="header-with-modal carousel-header">
+            <h3>
+              SALE!
+            </h3>
+            {carouselCodeModal}
+          </div>
+          <div className="header-with-modal carousel-text">
+            <p>{`Get this classic 50% off. `}
+              <Link
+                onClick={() => {
+                  onSlideClick('hjdf7', 25);
+                }}
+                to="/product/hjdf7"
+              >
               View Deal
-            </Link>
-          </p>
+              </Link>
+            </p>
+            {getSelectPromotionCodeModal('hjdf7', 25)}
+          </div>
         </Carousel.Caption>
       </Carousel.Item>
       <Carousel.Item>
@@ -103,17 +166,26 @@ export function HomeCarousel() {
           alt="Third slide"
         />
         <Carousel.Caption>
-          <h3 className="font-italic">Toe Beans</h3>
-          <p>{`Seen like never before. `}
-            <Link
-              onClick={() => {
-                onSlideClick('3h488');
-              }}
-              to="/product/3h488"
-            >
-              Buy Now
-            </Link>
-          </p>
+          <div className="header-with-modal carousel-header">
+            <h3 className="font-italic">
+              Toe Beans
+            </h3>
+            {carouselCodeModal}
+          </div>
+          <div className="header-with-modal carousel-text">
+            <p>
+              {`Seen like never before. `}
+              <Link
+                onClick={() => {
+                  onSlideClick('3h488');
+                }}
+                to="/product/3h488"
+              >
+                Buy Now
+              </Link>
+            </p>
+            {getSelectPromotionCodeModal('3h488')}
+          </div>
         </Carousel.Caption>
       </Carousel.Item>
     </Carousel>

--- a/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
+++ b/demo/src/screens/HomeScreen/HomeCarousel/HomeCarousel.js
@@ -62,7 +62,7 @@ export function HomeCarousel() {
           ...getItemParameters(itemId),
           promotion_name: 'Home Carousel',
           // if discount is positive, include it in the item parameter
-          ...(discount > 0 && {discount}),
+          ...(discount > 0 ? {discount} : {}),
         },
       ],
     };

--- a/demo/src/utils.js
+++ b/demo/src/utils.js
@@ -69,7 +69,7 @@ export function getItemParameters(itemId) {
     item_name: items[itemId].name,
     price: items[itemId].cost,
     // if quantity is positive, include it in the item parameter
-    ...(quantity > 0 && {quantity}),
+    ...(quantity > 0 ? {quantity} : {}),
   };
 }
 


### PR DESCRIPTION
NOTE: This is built on top of PR #29 and the diff will look incorrect until it is merged. View commit [757e4cc](https://github.com/googleinterns/measurement-library/commit/757e4cca45e7a4861f000283b8894acb92ddfbc4) to see correct code changes.

Adds code modals to the Home Carousel.

![image](https://user-images.githubusercontent.com/31981238/85333921-49d15500-b48f-11ea-86bb-60a42b704f1c.png)
