### PR TITLE
Set up Travis CI to run tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "14"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,16 @@ yarn install
 npm install
 ```
 
-Next, add karma to your path if it isn't already.
+Next, run the tests using yarn or npm:
+
+```shell script
+yarn test
+# or
+npm test
+```
+
+## Running tests interactively
+You can also run the tests "interactively" via Karma directly. Add Karma to your path if it isn't already:
 
 ```shell script
 yarn global add karma-cli
@@ -22,7 +31,7 @@ npm install -g karma-cli
 ```
 
 Next, run the tests with karma
+
 ```shell script
 karma start
 ```
-

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
     "karma-jasmine": "^3.3.1",
     "karma-jasmine-html-reporter": "^1.5.4",
     "karma-spec-reporter": "^0.0.32"
+  },
+  "scripts": {
+    "test": "karma start --single-run --browsers ChromeHeadless"
   }
 }


### PR DESCRIPTION
This is a Travis "MVP". By adding .travis.yml (along with the existing yarn.lock), Travis will run "yarn install" followed by "yarn test".

This PR also adds the "test" invocation in package.json. For now, it runs just the example tests that Alex set up in headless chrome.

The results of my latest run are here: https://travis-ci.com/github/durbanie/measurement-library