### PR TITLE
Create interfaces for eventProcessor and Storage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -23,11 +23,13 @@ module.exports = function(grunt) {
     'closure-compiler': {
       my_target: {
         files: {
-          'dist/measure.js': 'src/**/*.js',
+          'dist/measure.js': 'src/measure.js',
         },
         options: {
           js: [
-            'node_modules/google-closure-library/closure/goog/base.js'
+            'node_modules/google-closure-library/closure/goog/base.js',
+            'src/Storage/**/*.js',
+            'src/EventProcessor/**/*.js',
           ],
           hide_warnings_for: 'google-closure-library',
           warning_level: 'VERBOSE',

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,8 @@ module.exports = function(config) {
       // ------------------------ Source Files ---------------------------------
       // Dependencies must be listed before the file they are used in for
       // the googmodule preprocessor to function properly.
+      {pattern: 'src/Storage/**/*.js'},
+      {pattern: 'src/EventProcessor/**/*.js'},
       {pattern: 'src/**/*.js'},
       // ------------------------- Test Files ----------------------------------
       'test/*_test.js'

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -20,7 +20,7 @@ class EventProcessor {
    * @param {{get:function(string):*, set:function(string, *)}} modelInterface
    *    An interface to load or save short term page data from the data layer.
    * @param {string} eventName The name of the event passed to the data layer.
-   * @param {...*} eventArgs The events passed to the data layer
+   * @param {Object<string, *>} eventArgs The events passed to the data layer
    */
   processEvent(storageInterface, modelInterface, eventName, ...eventArgs) {};
 

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -13,7 +13,7 @@ goog.module('measurementlibrary.EventProcessor.EventProcessorInterface');
  */
 class EventProcessor {
   /**
-   * Process an event passed into the data layer.
+   * Processes an event passed into the data layer.
    *
    * @param {!StorageInterface} storageInterface An interface to an object to
    *    load or save persistent data with.
@@ -25,7 +25,7 @@ class EventProcessor {
   processEvent(storageInterface, modelInterface, eventName, ...eventArgs) {};
 
   /**
-   * Decide if a given key should be persisted to long term storage, or just
+   * Decides if a given key should be persisted to long term storage, or just
    * saved locally to the data layer.
    *
    * @param {string} key The location at which to store data.

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -22,7 +22,7 @@ class EventProcessor {
    * @param {string} eventName The name of the event passed to the data layer.
    * @param {Object<string, *>} eventArgs The events passed to the data layer
    */
-  processEvent(storageInterface, modelInterface, eventName, ...eventArgs) {};
+  processEvent(storageInterface, modelInterface, eventName, eventArgs) {};
 
   /**
    * Decides how long a given key should be persisted to long term storage for.

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -1,0 +1,39 @@
+goog.require('measurementlibrary.Storage.StorageInterface');
+goog.module('measurementlibrary.EventProcessor.EventProcessorInterface');
+
+/**
+ * A class implementing this interface can react to events pushed to the
+ * data layer.
+ * Event processors may perform actions such as sending a network request
+ * based on the event data, interacting with the storage interface to commit
+ * and retrieve values from long-term storage, or reading values from
+ * the abstract model.
+ *
+ * @interface
+ */
+class EventProcessor {
+  /**
+   * Process an event passed into the data layer.
+   *
+   * @param {!StorageInterface} storageInterface An interface to an object to
+   *    load or save persistent data with.
+   * @param {{get:function(string):*, set:function(string, *)}} modelInterface An
+   *    interface to load or save short term page data from the data layer.
+   * @param {string} eventName The name of the event passed to the data layer.
+   * @param {...*} eventArgs The events passed to the data layer
+   */
+  processEvent(storageInterface, modelInterface, eventName, ...eventArgs) {};
+
+  /**
+   * Decide if a given key should be persisted to long term storage, or just
+   * saved locally to the data layer.
+   *
+   * @param {string} key The location at which to store data.
+   * @param {*} value The data to store.
+   * @return {boolean} True iff the key should be persisted.
+   */
+  shouldPersist(key, value) {};
+
+}
+
+exports = EventProcessor;

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -17,22 +17,28 @@ class EventProcessor {
    *
    * @param {!StorageInterface} storageInterface An interface to an object to
    *    load or save persistent data with.
-   * @param {{get:function(string):*, set:function(string, *)}} modelInterface An
-   *    interface to load or save short term page data from the data layer.
+   * @param {{get:function(string):*, set:function(string, *)}} modelInterface
+   *    An interface to load or save short term page data from the data layer.
    * @param {string} eventName The name of the event passed to the data layer.
    * @param {...*} eventArgs The events passed to the data layer
    */
   processEvent(storageInterface, modelInterface, eventName, ...eventArgs) {};
 
   /**
-   * Decides if a given key should be persisted to long term storage, or just
-   * saved locally to the data layer.
+   * Decides how long a given key should be persisted to long term storage for.
+   * Regardless of the output, data will always be saved
+   * locally to the data layer.
    *
-   * @param {string} key The location at which to store data.
+   * @param {string} key The location at which to store data in the model.
+   *    Dot notation is used to access a nested value (i.e. 'employees.jim'
+   *    is the key 'jim' in the nested 'employees' object).
    * @param {*} value The data to store.
-   * @return {boolean} True iff the key should be persisted.
+   * @return {number} How long the key should be stored in seconds.
+   *     If -1, then the default value saved in storage will be used.
+   *     If 0, the data is not saved to long term storage at all.
+   *     If Number.POSITIVE_INFINITY, data will be stored forever.
    */
-  shouldPersist(key, value) {};
+  persistTime(key, value) {};
 
 }
 

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -20,7 +20,7 @@ class EventProcessor {
    * @param {{get:function(string):*, set:function(string, *)}} modelInterface
    *    An interface to load or save short term page data from the data layer.
    * @param {string} eventName The name of the event passed to the data layer.
-   * @param {Object<string, *>} eventArgs The events passed to the data layer
+   * @param {Object<string, *>} eventArgs The events passed to the data layer.
    */
   processEvent(storageInterface, modelInterface, eventName, eventArgs) {};
 

--- a/src/EventProcessor/EventProcessorInterface.js
+++ b/src/EventProcessor/EventProcessorInterface.js
@@ -20,7 +20,7 @@ class EventProcessor {
    * @param {{get:function(string):*, set:function(string, *)}} modelInterface
    *    An interface to load or save short term page data from the data layer.
    * @param {string} eventName The name of the event passed to the data layer.
-   * @param {Object<string, *>} eventArgs The events passed to the data layer.
+   * @param {!Object<string, *>=} eventArgs The events passed to the data layer.
    */
   processEvent(storageInterface, modelInterface, eventName, eventArgs) {};
 

--- a/src/Storage/StorageInterface.js
+++ b/src/Storage/StorageInterface.js
@@ -10,7 +10,9 @@ class StorageInterface {
    * Saves a key value pair into the storage interface for up to a
    * maximum time to live.
    *
-   * @param {string} key The location at which to store data.
+   * @param {string} key The location at which to store data in the model.
+   *    Dot notation is used to access a nested value (i.e. 'employees.jim'
+   *    is the key 'jim' in the nested 'employees' object).
    * @param {*} value The data to store.
    * @param {number=} secondsToLive The maximum number of seconds that the key
    *    should be saved for.
@@ -21,6 +23,9 @@ class StorageInterface {
    * Loads the value associated with a given key in the storageInterface.
    *
    * @param {string} key The location at which to load data.
+   * @param {string} key The location at which to store data in the model.
+   *    Dot notation is used to access a nested value (i.e. 'employees.jim'
+   *    is the key 'jim' in the nested 'employees' object).
    * @param {*=} defaultValue The value to load if no key is stored at
    *    the default location.
    * @return {*} value The data stored at the given location, or defaultValue

--- a/src/Storage/StorageInterface.js
+++ b/src/Storage/StorageInterface.js
@@ -1,0 +1,34 @@
+goog.module('measurementlibrary.Storage.StorageInterface');
+
+/**
+ * A class implementing this interface allows for storage and retrieval of data.
+ *
+ * @typedef StorageInterface
+ * @interface
+ */
+class StorageInterface {
+  /**
+   * Save a key value pair into the storage interface for up to a
+   * maximum time to live.
+   *
+   * @param {string} key The location at which to store data.
+   * @param {*} value The data to store.
+   * @param {number=} secondsToLive The maximum number of seconds that the key
+   *    should be saved for.
+   */
+  save(key, value, secondsToLive) {};
+
+  /**
+   * Load the value associated with a key at a particular location in the
+   * storageInterface.
+   *
+   * @param {string} key The location at which to load data.
+   * @param {*=} defaultValue The value to load if no key is stored at
+   *    the default location.
+   * @return {*} value The data stored at the given location, or defaultValue
+   *    if none exist.
+   */
+  load(key, defaultValue) {};
+}
+
+exports = StorageInterface;

--- a/src/Storage/StorageInterface.js
+++ b/src/Storage/StorageInterface.js
@@ -7,7 +7,7 @@ goog.module('measurementlibrary.Storage.StorageInterface');
  */
 class StorageInterface {
   /**
-   * Save a key value pair into the storage interface for up to a
+   * Saves a key value pair into the storage interface for up to a
    * maximum time to live.
    *
    * @param {string} key The location at which to store data.
@@ -18,8 +18,7 @@ class StorageInterface {
   save(key, value, secondsToLive) {};
 
   /**
-   * Load the value associated with a key at a particular location in the
-   * storageInterface.
+   * Loads the value associated with a given key in the storageInterface.
    *
    * @param {string} key The location at which to load data.
    * @param {*=} defaultValue The value to load if no key is stored at

--- a/src/Storage/StorageInterface.js
+++ b/src/Storage/StorageInterface.js
@@ -3,7 +3,6 @@ goog.module('measurementlibrary.Storage.StorageInterface');
 /**
  * A class implementing this interface allows for storage and retrieval of data.
  *
- * @typedef StorageInterface
  * @interface
  */
 class StorageInterface {

--- a/src/Storage/StorageInterface.js
+++ b/src/Storage/StorageInterface.js
@@ -22,11 +22,10 @@ class StorageInterface {
   /**
    * Loads the value associated with a given key in the storageInterface.
    *
-   * @param {string} key The location at which to load data.
    * @param {string} key The location at which to store data in the model.
    *    Dot notation is used to access a nested value (i.e. 'employees.jim'
    *    is the key 'jim' in the nested 'employees' object).
-   * @param {*=} defaultValue The value to load if no key is stored at
+   * @param {*=} defaultValue The value to return if no key is stored at
    *    the default location.
    * @return {*} value The data stored at the given location, or defaultValue
    *    if none exist.


### PR DESCRIPTION
This commit creates interfaces for the eventProcessor and Storage. This is important since this library will potentially support several different kinds of eventProcessor/Storage classes and this provides a foundation that can be built off of and referenced in the future. Also it helps with jsdoc.

One change I wasn't sure about was documenting the processEvent function of EventProcessor. It uses rest parameters for more clarity. I think that no polyfill will happen since this is just an interface, but it may be worth checking out the dist size once we have an implementation to make sure that this is true.
