### PR TITLE
Add error handling and logging to Event Processor

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function(config) {
       {pattern: 'data-layer-helper/src/helper/utils.js'},
       {pattern: 'data-layer-helper/src/helper/data-layer-helper.js'},
       // ------------------------ Source Files ---------------------------------
+      {pattern: 'src/logging.js'},
       {pattern: 'src/storage/**/*.js'},
       {pattern: 'src/eventProcessor/**/*.js'},
       {pattern: 'src/logging.js'},

--- a/src/eventProcessor/GoogleAnalyticsEventProcessor.js
+++ b/src/eventProcessor/GoogleAnalyticsEventProcessor.js
@@ -66,7 +66,7 @@ class GoogleAnalyticsEventProcessor {
       'measurement_id': measurementId,
       'measurement_url': measurementUrl,
       'client_id_expires': clientIdExpires,
-      'automatic_params': userAutomaticParams = [],
+      'automatic_params': userAutomaticParams,
     } = {}) {
     if (apiSecret !== undefined && typeof apiSecret !== 'string') {
       logging.log(

--- a/src/eventProcessor/GoogleAnalyticsEventProcessor.js
+++ b/src/eventProcessor/GoogleAnalyticsEventProcessor.js
@@ -16,6 +16,12 @@ const TOP_LEVEL_PARAMS = {
 };
 
 /**
+ * Default client ID expires value.
+ * @const {number}
+ */
+const DEFAULT_CLIENT_ID_EXPIRES = 2 * 365 * 24 * 60 * 60;
+
+/**
  * Returns the default Google Analytics measurement URL
  * depending on if debug mode has been enabled.
  * When in debug mode, events get sent to the debug Google Analytics
@@ -103,11 +109,11 @@ class GoogleAnalyticsEventProcessor {
       if (clientIdExpires !== undefined) {
         logging.log(
           'Provided Client ID Expires is not a valid number. ' +
-              'Using default of two years instead.',
+              'Using default value instead.',
           logging.LogLevel.ERROR
         );
       }
-      clientIdExpires = 2 * 365 * 24 * 60 * 60;
+      clientIdExpires = DEFAULT_CLIENT_ID_EXPIRES;
     } else {
       clientIdExpires = Number(clientIdExpires);
     }

--- a/src/eventProcessor/GoogleAnalyticsEventProcessor.js
+++ b/src/eventProcessor/GoogleAnalyticsEventProcessor.js
@@ -105,7 +105,7 @@ class GoogleAnalyticsEventProcessor {
         );
       }
     }
-    if (clientIdExpires === undefined || isNaN(Number(clientIdExpires))) {
+    if (isNaN(Number(clientIdExpires))) {
       if (clientIdExpires !== undefined) {
         logging.log(
           'Provided Client ID Expires is not a valid number. ' +

--- a/src/eventProcessor/GoogleAnalyticsEventProcessor.js
+++ b/src/eventProcessor/GoogleAnalyticsEventProcessor.js
@@ -91,6 +91,13 @@ class GoogleAnalyticsEventProcessor {
         );
       }
       measurementUrl = getDefaultMeasurementUrl();
+      if (measurementId === undefined || apiSecret === undefined) {
+        logging.log(
+          'Sending events to Google Analytics without measurement ID or ' +
+              'API secret will lead to events being dropped.',
+          logging.LogLevel.ERROR
+        );
+      }
     }
     if (clientIdExpires === undefined || isNaN(Number(clientIdExpires))) {
       if (clientIdExpires !== undefined) {

--- a/src/logging.js
+++ b/src/logging.js
@@ -42,6 +42,7 @@ function log(toLog, logLevel) {
 }
 
 exports = {
+  DEBUG,
   LogLevel,
   log,
 };

--- a/test/unit/GoogleAnalyticsEventProcessor/buildRequestUrl_test.js
+++ b/test/unit/GoogleAnalyticsEventProcessor/buildRequestUrl_test.js
@@ -2,9 +2,12 @@ goog.module('measurementLibrary.eventProcessor.testing.GoogleAnalyticsEventProce
 goog.setTestOnly();
 
 const GoogleAnalyticsEventProcessor = goog.require('measurementLibrary.eventProcessor.GoogleAnalyticsEventProcessor');
+const logging = goog.require('measurementLibrary.logging');
 
 describe('The `buildRequestUrl_` method ' +
     'of GoogleAnalyticsEventProcessor', () => {
+  const currentDebug = logging.DEBUG;
+
   /**
    * Builds expectation object for the `buildRequestUrl_` function by passing
    * in an API secret, measurement ID, and measurement URL to construct the
@@ -23,34 +26,6 @@ describe('The `buildRequestUrl_` method ' +
 
     return expect(eventProcessor.buildRequestUrl_());
   }
-
-  it('creates the correct query string when using the default ' +
-      'measurement url', () => {
-    expectRequestUrl(
-      /* apiSecret */ '123',
-      /* measurementId */ '456',
-      /* measurementUrl */ undefined
-    ).toBe('https://www.google-analytics.com/mp/collect?' +
-        'measurement_id=456&api_secret=123');
-
-    expectRequestUrl(
-      /* apiSecret */ undefined,
-      /* measurementId */ '456',
-      /* measurementUrl */ undefined
-    ).toBe('https://www.google-analytics.com/mp/collect?measurement_id=456');
-
-    expectRequestUrl(
-      /* apiSecret */ '123',
-      /* measurementId */ undefined,
-      /* measurementUrl */ undefined
-    ).toBe('https://www.google-analytics.com/mp/collect?api_secret=123');
-
-    expectRequestUrl(
-      /* apiSecret */ undefined,
-      /* measurementId */ undefined,
-      /* measurementUrl */ undefined
-    ).toBe('https://www.google-analytics.com/mp/collect');
-  });
 
   it('creates the correct query string when using an overriden ' +
       'measurement url', () => {
@@ -81,10 +56,11 @@ describe('The `buildRequestUrl_` method ' +
 
   it('encodes query parameters', () => {
     expectRequestUrl(
-      /* apiSecret */ '12 3',
-      /* measurementId */ '45 6',
+      /* apiSecret */ '123&other_param=other_arg',
+      /* measurementId */ '456',
       /* measurementUrl */ 'https://test.com'
-    ).toBe('https://test.com?measurement_id=45%206&api_secret=12%203');
+    ).toBe('https://test.com?' +
+        'measurement_id=456&api_secret=123%26other_param%3Dother_arg');
   });
 
   it('does not add empty strings as query parameters', () => {
@@ -105,5 +81,77 @@ describe('The `buildRequestUrl_` method ' +
       /* measurementId */ '',
       /* measurementUrl */ 'https://test.com'
     ).toBe('https://test.com');
+  });
+
+  describe('when debug mode is disabled', () => {
+    beforeAll(() => {
+      logging.DEBUG = false;
+    });
+
+    it('creates the correct query string when using the default ' +
+    'measurement url', () => {
+      expectRequestUrl(
+        /* apiSecret */ '123',
+        /* measurementId */ '456',
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/mp/collect?' +
+          'measurement_id=456&api_secret=123');
+
+      expectRequestUrl(
+        /* apiSecret */ undefined,
+        /* measurementId */ '456',
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/mp/collect?measurement_id=456');
+
+      expectRequestUrl(
+        /* apiSecret */ '123',
+        /* measurementId */ undefined,
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/mp/collect?api_secret=123');
+
+      expectRequestUrl(
+        /* apiSecret */ undefined,
+        /* measurementId */ undefined,
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/mp/collect');
+    });
+  });
+
+  describe('when debug mode is enabled', () => {
+    beforeAll(() => {
+      logging.DEBUG = true;
+    });
+
+    it('creates the correct query string when using the debug ' +
+        'measurement url', () => {
+      expectRequestUrl(
+        /* apiSecret */ '123',
+        /* measurementId */ '456',
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/debug/mp/collect?' +
+          'measurement_id=456&api_secret=123');
+
+      expectRequestUrl(
+        /* apiSecret */ undefined,
+        /* measurementId */ '456',
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/debug/mp/collect?measurement_id=456');
+
+      expectRequestUrl(
+        /* apiSecret */ '123',
+        /* measurementId */ undefined,
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/debug/mp/collect?api_secret=123');
+
+      expectRequestUrl(
+        /* apiSecret */ undefined,
+        /* measurementId */ undefined,
+        /* measurementUrl */ undefined
+      ).toBe('https://www.google-analytics.com/debug/mp/collect');
+    });
+  });
+
+  afterAll(() => {
+    logging.DEBUG = currentDebug;
   });
 });

--- a/test/unit/GoogleAnalyticsEventProcessor/constructor_test.js
+++ b/test/unit/GoogleAnalyticsEventProcessor/constructor_test.js
@@ -87,49 +87,65 @@ describe('The `constructor` of GoogleAnalyticsEventProcessor', () => {
       expect(eventProcessor.measurementUrl_).toBe('https://www.google-analytics.com/debug/mp/collect');
     });
 
-    it('only logs error to console if `api secret` is not valid string', () => {
+    it('logs an error if either `measurement_id` or `api_secret` ' +
+        'are undefined while events are being sent to analytics', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor();
+
+      expect(logging.log).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs error to console if `api secret` is not valid string', () => {
       spyOn(logging, 'log');
       eventProcessor = new GoogleAnalyticsEventProcessor({
         api_secret: 'valid_string',
-      });
-
-      expect(logging.log).toHaveBeenCalledTimes(0);
-
-      eventProcessor = new GoogleAnalyticsEventProcessor({
-        api_secret: {},
-      });
-
-      expect(logging.log).toHaveBeenCalledTimes(1);
-      expect(eventProcessor.apiSecret_).toBeUndefined();
-    });
-
-    it('only logs error to console if `measurement_id` is not ' +
-        'valid string', () => {
-      spyOn(logging, 'log');
-      eventProcessor = new GoogleAnalyticsEventProcessor({
         measurement_id: 'valid_string',
       });
 
       expect(logging.log).toHaveBeenCalledTimes(0);
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
-        measurement_id: 123456,
+        api_secret: {},
+        measurement_id: 'valid_string',
       });
 
-      expect(logging.log).toHaveBeenCalledTimes(1);
-      expect(eventProcessor.measurementId_).toBeUndefined();
+      expect(logging.log).toHaveBeenCalledTimes(2);
+      expect(eventProcessor.apiSecret_).toBeUndefined();
     });
 
-    it('only logs error to console if `measurement_url` is not ' +
+    it('logs error to console if `measurement_id` is not ' +
         'valid string', () => {
       spyOn(logging, 'log');
       eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: 'valid_string',
+        measurement_id: 'valid_string',
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: 'valid_string',
+        measurement_id: 123456,
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(2);
+      expect(eventProcessor.measurementId_).toBeUndefined();
+    });
+
+    it('logs error to console if `measurement_url` is not ' +
+        'valid string', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: 'valid_string',
+        measurement_id: 'valid_string',
         measurement_url: 'valid_string',
       });
 
       expect(logging.log).toHaveBeenCalledTimes(0);
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: 'valid_string',
+        measurement_id: 'valid_string',
         measurement_url: [],
       });
 
@@ -138,23 +154,29 @@ describe('The `constructor` of GoogleAnalyticsEventProcessor', () => {
           .toBe('https://www.google-analytics.com/debug/mp/collect');
     });
 
-    it('only logs error to console if `client_id_expires` is not ' +
+    it('logs error to console if `client_id_expires` is not ' +
         'able to be cast as a number', () => {
       spyOn(logging, 'log');
       eventProcessor = new GoogleAnalyticsEventProcessor({
         client_id_expires: '1', // casts to one
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(eventProcessor.clientIdExpires_).toBe(1);
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
         client_id_expires: [], // casts to zero
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(eventProcessor.clientIdExpires_).toBe(0);
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
         client_id_expires: undefined, // uses default instead of casting to zero
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(eventProcessor.clientIdExpires_).toBe(2 * 365 * 24 * 60 * 60);
@@ -163,25 +185,33 @@ describe('The `constructor` of GoogleAnalyticsEventProcessor', () => {
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
         client_id_expires: {},
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
       eventProcessor = new GoogleAnalyticsEventProcessor({
         client_id_expires: 'invalid_number',
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(logging.log).toHaveBeenCalledTimes(2);
     });
 
-    it('only logs error to console if `automatic_params` is not ' +
+    it('logs error to console if `automatic_params` is not ' +
         'an array', () => {
       spyOn(logging, 'log');
       eventProcessor = new GoogleAnalyticsEventProcessor({
         automatic_params: ['test'],
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(logging.log).toHaveBeenCalledTimes(0);
 
       eventProcessor = new GoogleAnalyticsEventProcessor({
         automatic_params: {test: 1},
+        api_secret: 'valid_string',
+        measurement_url: 'valid_string',
       });
 
       expect(logging.log).toHaveBeenCalledTimes(1);

--- a/test/unit/GoogleAnalyticsEventProcessor/constructor_test.js
+++ b/test/unit/GoogleAnalyticsEventProcessor/constructor_test.js
@@ -2,9 +2,11 @@ goog.module('measurementLibrary.eventProcessor.testing.GoogleAnalyticsEventProce
 goog.setTestOnly();
 
 const GoogleAnalyticsEventProcessor = goog.require('measurementLibrary.eventProcessor.GoogleAnalyticsEventProcessor');
+const logging = goog.require('measurementLibrary.logging');
 
 describe('The `constructor` of GoogleAnalyticsEventProcessor', () => {
   let eventProcessor;
+  const currentDebug = logging.DEBUG;
 
   const defaultAutomaticParams = {
     'page_path': true,
@@ -22,53 +24,172 @@ describe('The `constructor` of GoogleAnalyticsEventProcessor', () => {
     expect(eventProcessor.measurementId_).toBeUndefined();
   });
 
-  it('has the correct default arguments for `measurement_url`, ' +
+  it('has default arguments for `measurement_url`, ' +
   '`client_id_expires`, and `automatic_params`', () => {
+    logging.DEBUG = false;
     eventProcessor = new GoogleAnalyticsEventProcessor();
 
     expect(eventProcessor.measurementUrl_).toBe('https://www.google-analytics.com/mp/collect');
     expect(eventProcessor.clientIdExpires_).toBe(2 * 365 * 24 * 60 * 60);
     expect(eventProcessor.automaticParams_).toEqual(defaultAutomaticParams);
+    logging.DEBUG = currentDebug;
   });
 
-  it('correctly sets `api_secret`', () => {
+  it('sets `api_secret`', () => {
     eventProcessor = new GoogleAnalyticsEventProcessor({
-      'api_secret': 'test_api_secret',
+      api_secret: 'test_api_secret',
     });
 
     expect(eventProcessor.apiSecret_).toBe('test_api_secret');
   });
 
-  it('correctly sets `measurement_id`', () => {
+  it('sets `measurement_id`', () => {
     eventProcessor = new GoogleAnalyticsEventProcessor({
-      'measurement_id': 'test_measurement_id',
+      measurement_id: 'test_measurement_id',
     });
 
     expect(eventProcessor.measurementId_).toBe('test_measurement_id');
   });
 
-  it('correctly overrides `measurement_url`', () => {
+  it('overrides `measurement_url`', () => {
     eventProcessor = new GoogleAnalyticsEventProcessor({
-      'measurement_url': 'test_url',
+      measurement_url: 'test_url',
     });
 
     expect(eventProcessor.measurementUrl_).toBe('test_url');
   });
 
-  it('correctly overrides `client_id_expires`', () => {
+  it('overrides `client_id_expires`', () => {
     eventProcessor = new GoogleAnalyticsEventProcessor({
-      'client_id_expires': 0,
+      client_id_expires: 600,
     });
 
-    expect(eventProcessor.clientIdExpires_).toBe(0);
+    expect(eventProcessor.clientIdExpires_).toBe(600);
   });
 
-  it('correctly sets `automatic_params`', () => {
+  it('sets `automatic_params`', () => {
     eventProcessor = new GoogleAnalyticsEventProcessor({
-      'automatic_params': ['custom_param'],
+      automatic_params: ['custom_param'],
     });
 
     expect(eventProcessor.automaticParams_['client_id']).toBeTrue();
     expect(eventProcessor.automaticParams_['custom_param']).toBeTrue();
+  });
+
+  describe('when debug mode is enabled', () => {
+    beforeAll(() => {
+      logging.DEBUG = true;
+    });
+
+    it('overrides default `measurement_url` to use debug analytics', () => {
+      eventProcessor = new GoogleAnalyticsEventProcessor();
+
+      expect(eventProcessor.measurementUrl_).toBe('https://www.google-analytics.com/debug/mp/collect');
+    });
+
+    it('only logs error to console if `api secret` is not valid string', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: 'valid_string',
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        api_secret: {},
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(1);
+      expect(eventProcessor.apiSecret_).toBeUndefined();
+    });
+
+    it('only logs error to console if `measurement_id` is not ' +
+        'valid string', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        measurement_id: 'valid_string',
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        measurement_id: 123456,
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(1);
+      expect(eventProcessor.measurementId_).toBeUndefined();
+    });
+
+    it('only logs error to console if `measurement_url` is not ' +
+        'valid string', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        measurement_url: 'valid_string',
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        measurement_url: [],
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(1);
+      expect(eventProcessor.measurementUrl_)
+          .toBe('https://www.google-analytics.com/debug/mp/collect');
+    });
+
+    it('only logs error to console if `client_id_expires` is not ' +
+        'able to be cast as a number', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        client_id_expires: '1', // casts to one
+      });
+
+      expect(eventProcessor.clientIdExpires_).toBe(1);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        client_id_expires: [], // casts to zero
+      });
+
+      expect(eventProcessor.clientIdExpires_).toBe(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        client_id_expires: undefined, // uses default instead of casting to zero
+      });
+
+      expect(eventProcessor.clientIdExpires_).toBe(2 * 365 * 24 * 60 * 60);
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        client_id_expires: {},
+      });
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        client_id_expires: 'invalid_number',
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(2);
+    });
+
+    it('only logs error to console if `automatic_params` is not ' +
+        'an array', () => {
+      spyOn(logging, 'log');
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        automatic_params: ['test'],
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(0);
+
+      eventProcessor = new GoogleAnalyticsEventProcessor({
+        automatic_params: {test: 1},
+      });
+
+      expect(logging.log).toHaveBeenCalledTimes(1);
+      expect(eventProcessor.automaticParams_).toEqual(defaultAutomaticParams);
+    });
+
+    afterAll(() => {
+      logging.DEBUG = currentDebug;
+    });
   });
 });


### PR DESCRIPTION
Checks for invalid user input in constructor arguments and sets arguments to default value if detected. Also logs an error when in Debug mode.

Changes default measurement URL to Google Analytics debug server if debug is detected.

Adds tests for these changes.