### PR TITLE
Merge scopes together when calling the event command

### DIFF
--- a/src/config/configProcessors.js
+++ b/src/config/configProcessors.js
@@ -113,8 +113,37 @@ function configProcessors(helper, eventProcessor, eventOptions,
   // Process an event object by sending it to the registered event processor
   // along with interfaces to the storage and data layer helper.
   function processEvent(name, options = undefined) {
+    /**
+     *  Perform a merge on the given list of objects. Any properties that both
+     *  the ith and jth (i less than j) objects both share will be overwritten
+     *  to have just the property of the jth object.
+     *  This jsdoc is needed so the compiler doesn't warn
+     *
+     *  @param {...} args The objects to merge.
+     *  @return {!Object<string, *>}
+     */
+    const merge = function(args) {
+      const result = {};
+      for (let i = 0; i < arguments.length; i++) {
+        const toMerge = arguments[i];
+        for (const prop in toMerge) {
+          if (toMerge.hasOwnProperty(prop)) {
+            result[prop] = toMerge[prop];
+          }
+        }
+      }
+      return result;
+    };
+
+    const getExtraOptions = (object) => {
+      if (object && object.hasOwnProperty('getName')) {
+        return helper.get(object.getName());
+      }
+      return {};
+    };
     const model = this;
     if (!options) options = {};
+    options = merge(getExtraOptions(processor), eventOptions, options);
     processor.processEvent(/** @type {!StorageInterface} */(storage),
       model, name, options);
   }

--- a/src/config/configProcessors.js
+++ b/src/config/configProcessors.js
@@ -150,7 +150,8 @@ function configProcessors(helper, eventProcessor, eventOptions,
   function processEvent(name, options = undefined) {
     const model = this;
     if (!options) options = {};
-    options = merge(getExtraOptions(helper, processor), eventOptions, options);
+    options = merge(getExtraOptions(helper, processor.constructor),
+      eventOptions, options);
     processor.processEvent(/** @type {!StorageInterface} */(storage),
       model, name, options);
   }

--- a/src/config/configProcessors.js
+++ b/src/config/configProcessors.js
@@ -84,6 +84,45 @@ function buildProcessor_(constructor, params) {
 }
 
 /**
+ *  Perform a merge on the given list of objects. Any properties that both
+ *  the ith and jth (i less than j) objects both share will be overwritten
+ *  to have just the property of the jth object.
+ *
+ *  @param {...} args The objects to merge.
+ *  @return {!Object<string, *>}
+ */
+const merge = function(args) {
+  const result = {};
+  for (let i = 0; i < arguments.length; i++) {
+    const toMerge = arguments[i];
+    for (const prop in toMerge) {
+      if (toMerge.hasOwnProperty(prop)) {
+        if (toMerge[prop] === undefined) {
+          delete result[prop];
+        } else {
+          result[prop] = toMerge[prop];
+        }
+      }
+    }
+  }
+  return result;
+};
+
+/**
+ *  Get extra parameters that are stored in the data layer for a given object.
+ *
+ *  @param {?DataLayerHelper} helper
+ *  @param {?Object} object The object that we would like to get parameters of.
+ *  @return {!Object<string, *>}
+ */
+const getExtraOptions = (helper, object) => {
+  if (helper && object && object.hasOwnProperty('getName')) {
+    return /** @type {!Object<string, *>} */ (helper.get(object.getName()));
+  }
+  return {};
+};
+
+/**
  * When called with an implementation of the eventProcessor and
  * storageInterface API, this function registers processors to react to the
  * 'set' and 'event' commands.
@@ -113,37 +152,9 @@ function configProcessors(helper, eventProcessor, eventOptions,
   // Process an event object by sending it to the registered event processor
   // along with interfaces to the storage and data layer helper.
   function processEvent(name, options = undefined) {
-    /**
-     *  Perform a merge on the given list of objects. Any properties that both
-     *  the ith and jth (i less than j) objects both share will be overwritten
-     *  to have just the property of the jth object.
-     *  This jsdoc is needed so the compiler doesn't warn
-     *
-     *  @param {...} args The objects to merge.
-     *  @return {!Object<string, *>}
-     */
-    const merge = function(args) {
-      const result = {};
-      for (let i = 0; i < arguments.length; i++) {
-        const toMerge = arguments[i];
-        for (const prop in toMerge) {
-          if (toMerge.hasOwnProperty(prop)) {
-            result[prop] = toMerge[prop];
-          }
-        }
-      }
-      return result;
-    };
-
-    const getExtraOptions = (object) => {
-      if (object && object.hasOwnProperty('getName')) {
-        return helper.get(object.getName());
-      }
-      return {};
-    };
     const model = this;
     if (!options) options = {};
-    options = merge(getExtraOptions(processor), eventOptions, options);
+    options = merge(getExtraOptions(helper, processor), eventOptions, options);
     processor.processEvent(/** @type {!StorageInterface} */(storage),
       model, name, options);
   }

--- a/src/config/configProcessors.js
+++ b/src/config/configProcessors.js
@@ -97,9 +97,7 @@ const merge = function(args) {
     const toMerge = arguments[i];
     for (const prop in toMerge) {
       if (toMerge.hasOwnProperty(prop)) {
-        if (toMerge[prop] !== undefined) {
-          result[prop] = toMerge[prop];
-        }
+        result[prop] = toMerge[prop];
       }
     }
   }

--- a/src/config/configProcessors.js
+++ b/src/config/configProcessors.js
@@ -97,9 +97,7 @@ const merge = function(args) {
     const toMerge = arguments[i];
     for (const prop in toMerge) {
       if (toMerge.hasOwnProperty(prop)) {
-        if (toMerge[prop] === undefined) {
-          delete result[prop];
-        } else {
+        if (toMerge[prop] !== undefined) {
           result[prop] = toMerge[prop];
         }
       }

--- a/src/config/setup.js
+++ b/src/config/setup.js
@@ -30,9 +30,10 @@ function setupMeasure(dataLayer) {
   const helper = new DataLayerHelper(dataLayer, {'processNow': false});
 
   helper.registerProcessor('config',
-      (eventProcessor, eventOptions, storageProcessor, storageOptions) =>
+      (eventProcessor, eventOptions, storageProcessor, storageOptions) => {
         configProcessors(helper, eventProcessor, eventOptions,
-            storageProcessor, storageOptions));
+            storageProcessor, storageOptions);
+      });
   helper.process();
 }
 

--- a/src/config/setup.js
+++ b/src/config/setup.js
@@ -30,10 +30,9 @@ function setupMeasure(dataLayer) {
   const helper = new DataLayerHelper(dataLayer, {'processNow': false});
 
   helper.registerProcessor('config',
-      (eventProcessor, eventOptions, storageProcessor, storageOptions) => {
+      (eventProcessor, eventOptions, storageProcessor, storageOptions) =>
         configProcessors(helper, eventProcessor, eventOptions,
-            storageProcessor, storageOptions);
-      });
+            storageProcessor, storageOptions));
   helper.process();
 }
 

--- a/test/unit/config/buildProcessor_test.js
+++ b/test/unit/config/buildProcessor_test.js
@@ -7,14 +7,14 @@ const GoogleAnalyticsEventProcessor = goog.require('measurementLibrary.eventProc
 describe('Calling the buildProcessor_ function of configProcessors', () => {
   it('returns an event processor when a valid string is passed', () => {
     expect(buildProcessor_('googleAnalytics', {})).toBeInstanceOf(
-        GoogleAnalyticsEventProcessor);
+      GoogleAnalyticsEventProcessor);
   });
 
-  it('returns an event processor when a class is passed in ',
-      () => {
-        expect(buildProcessor_(GoogleAnalyticsEventProcessor, {}))
-          .toBeInstanceOf(GoogleAnalyticsEventProcessor);
-      });
+  it('returns an event processor when a class is passed in ', () => {
+    expect(buildProcessor_(GoogleAnalyticsEventProcessor, {}))
+      .toBeInstanceOf(GoogleAnalyticsEventProcessor);
+  });
+
   it('eeturns false when an invalid string is passed in ', () => {
     expect(buildProcessor_('unimplemented', {})).toEqual(null);
   });

--- a/test/unit/config/processEvent_test.js
+++ b/test/unit/config/processEvent_test.js
@@ -1,0 +1,107 @@
+goog.module('measurementLibrary.testing.config.processEventConstructor');
+goog.setTestOnly();
+
+describe('After calling measure with `event` as the first parameter', () => {
+  let load;
+  let save;
+  let persistTime;
+  let processEvent;
+  let measure;
+  let dataLayer;
+
+  // Create a Mock Storage and Mock Processor object. Note that we cannot
+  // use jasmine.createSpyObject since it does not have a constructor.
+  // We need a class that will create an instance of itself that we can then
+  // access. Here this is done by making each method a spy.
+  class MockStorage {
+    constructor() {
+      this.load = load;
+      this.save = save;
+    }
+  }
+
+  class MockProcessor {
+    constructor() {
+      this.persistTime = persistTime;
+      this.processEvent = processEvent;
+    }
+    static getName() {
+      return 'processor';
+    }
+  }
+
+  beforeEach(() => {
+    load = jasmine.createSpy('load');
+    save = jasmine.createSpy('save');
+    persistTime = jasmine.createSpy('persistTime');
+    processEvent = jasmine.createSpy('processEvent');
+    // Reset the data layer we are using.
+    dataLayer = [];
+    measure = function() {
+      dataLayer.push(arguments);
+    };
+    setupMeasure(dataLayer);
+  });
+
+
+  describe('The call forwarded after a call to measure(`event`, ...)', () => {
+    /* TODO:(wolfblue@): Fix the issue here, it stems from data layer helper
+    it('inherits any parameters from set called before the constructor',
+      () => {
+        measure('set', 'processor', {'cat': 'meow'});
+        measure('config', MockProcessor, {'dog': 'woof'}, MockStorage, {});
+        measure('event', 'name');
+        expect(processEvent).toHaveBeenCalledWith(
+          jasmine.any(MockStorage), {
+            get: jasmine.any(Function),
+            set: jasmine.any(Function),
+          }, 'name', {'cat': 'meow', 'dog': 'woof'});
+      });
+
+    it('inherits any parameters from set called after the constructor',
+      () => {
+        measure('config', MockProcessor, {'dog': 'woof'}, MockStorage, {});
+        measure('set', 'processor', {'cat': 'meow'});
+        measure('event', 'name');
+        expect(processEvent).toHaveBeenCalledWith(
+          jasmine.any(MockStorage), {
+            get: jasmine.any(Function),
+            set: jasmine.any(Function),
+          }, 'name', {'cat': 'meow', 'dog': 'woof'});
+      });
+    */
+
+    it('does not inherit if set is called unscoped', () => {
+      measure('config', MockProcessor, {'dog': 'woof'}, MockStorage, {});
+      measure('set', {'cat': 'meow'});
+      measure('event', 'name');
+      expect(processEvent).toHaveBeenCalledWith(
+        jasmine.any(MockStorage), {
+          get: jasmine.any(Function),
+          set: jasmine.any(Function),
+        }, 'name', {'dog': 'woof'});
+    });
+
+    it('inherits from the config constructor over the set constructor', () => {
+      measure('set', 'processor', {'cat': 'bad'});
+      measure('config', MockProcessor, {'cat': 'meow'}, MockStorage, {});
+      measure('event', 'name');
+      expect(processEvent).toHaveBeenCalledWith(
+        jasmine.any(MockStorage), {
+          get: jasmine.any(Function),
+          set: jasmine.any(Function),
+        }, 'name', {'cat': 'meow'});
+    });
+
+    it('inherits from the event constructor if possible', () => {
+      measure('set', 'processor', {'cat': 'bad'});
+      measure('config', MockProcessor, {'cat': 'meow'}, MockStorage, {});
+      measure('event', 'name', {'cat': 'meowzer'});
+      expect(processEvent).toHaveBeenCalledWith(
+        jasmine.any(MockStorage), {
+          get: jasmine.any(Function),
+          set: jasmine.any(Function),
+        }, 'name', {'cat': 'meowzer'});
+    });
+  });
+});

--- a/test/unit/config/processEvent_test.js
+++ b/test/unit/config/processEvent_test.js
@@ -45,7 +45,6 @@ describe('After calling measure with `event` as the first parameter', () => {
 
 
   describe('The call forwarded after a call to measure(`event`, ...)', () => {
-    /* TODO:(wolfblue@): Fix the issue here, it stems from data layer helper
     it('inherits any parameters from set called before the constructor',
       () => {
         measure('set', 'processor', {'cat': 'meow'});
@@ -69,7 +68,6 @@ describe('After calling measure with `event` as the first parameter', () => {
             set: jasmine.any(Function),
           }, 'name', {'cat': 'meow', 'dog': 'woof'});
       });
-    */
 
     it('does not inherit if set is called unscoped', () => {
       measure('config', MockProcessor, {'dog': 'woof'}, MockStorage, {});


### PR DESCRIPTION
This commit updates the event command. The final parameter should include not just those parameters defined in the command, but also those defined by calling the command `measure('set, 'processorName', {paramsTo: 'persist'})`, and those defined in the constructor.

There are some issues with the set command that cause it not to work for now, explained here: https://docs.google.com/document/d/1BRUjcRSOG2cX1okcjbqsXlCM62wozotrvniEYjz736Q/edit#
It should work when data layer helper is updated (https://github.com/google/data-layer-helper/pull/59)