### PR TITLE
Event processor readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,22 @@ measure('config', 'eventProcessorName', {}, 'cookies', {expires: 22});
 ```
 
 # Event Processors
-Events are processed with event options arguments. These can
+When `measure('event', 'eventName', eventOptions)` is called, every configured event processor will be given a
+chance to react to that event with the given options. They can also interact with the storage by overriding the
+default time to live for specific keys.
+
+Event processors may perform actions such as sending a network request based on the event data, interacting with
+the storage interface to commit and retrieve values from long-term storage, or reading values from the abstract model.
 
 ## Google Analytics
 To configure the Google Analytics event processor, constructor arguments can be passed in via the [code snippet](#installation).
 
 The supported constructor arguments are:
-* api_secret: The Google Analytics API Secret. The API secret can be generated via Google Analytics UI. Required when using the default measurement URL. If included, it will be added as a query parameter.
-* measurement_id: The property to be measured's Google Analytics measurement ID. Can be found via Google Analytics UI. Required when using the default measurement URL.
-* measurement_url: URL endpoint to send events to. Defaults to Google Analytics collection endpoint. Optional. If overriden, the user will need to ensure the URL forwards events to Google Analytics.
-* client_id_expires: Time in seconds to store the client ID in long term storage. Defaults to two years. Optional.
-* automatic_params: Array of event parameters that will be searched for in the global data model and pulled into all events if found. Optional.
+* `api_secret`: The Google Analytics API Secret. The API secret can be generated via Google Analytics UI. Required when using the default measurement URL. If included, it will be added as a query parameter.
+* `measurement_id`: The property to be measured's Google Analytics measurement ID. Can be found via Google Analytics UI. Required when using the default measurement URL.
+* `measurement_url`: URL endpoint to send events to. Defaults to Google Analytics collection endpoint. Optional. If overriden, the user will need to ensure the URL forwards events to Google Analytics.
+* `client_id_expires`: Time in seconds to store the client ID in long term storage. Defaults to two years. Optional.
+* `automatic_params`: Array of event parameters that will be searched for in the global data model and pulled into all events if found. Optional.
 
 A basic example:
 
@@ -126,6 +131,8 @@ measure(
 ```
 
 Events are processed and sent to Google Analytics using the [event command](#event-command).
+A complete description of events that can be sent is described in the [gtag documentation.](https://developers.google.com/analytics/devguides/collection/gtagjs/pages) 
+You will need to replace the call `gtag('event', ...)` with `measure('event', ...)`.
 
 For a simple page view event with some supporting data, the user could call:
 
@@ -136,11 +143,11 @@ measure('event', 'page_view', {
 });
 ```
 
-This will send a page_view event to Google Analytics with the event parameters provided. In addition
+This will send a `page_view` event to Google Analytics with the event parameters provided. In addition
 to the event level parameters provided, the user can set event parameters using the [set command](#set-command) that will
 then be included in the event sent to Google Analytics even if not explicitly provided in the event command.
 
-To do this for all Google Analytics event processors, an example would be:
+For example, to set the currency to USD for  all Google Analytics event processors:
 
 ```js
 measure('set', 'googleAnalytics', {
@@ -154,7 +161,7 @@ to CAD instead of the previously set USD.
 
 ```js
 measure('event', 'purchase', {
-  'value' 99,
+  'value': 99,
   'currency': 'CAD',
 });
 ```

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Events are processed with event options arguments. These can
 To configure the Google Analytics event processor, constructor arguments can be passed in via the [code snippet](#installation).
 
 The supported constructor arguments are:
-* api_secret: The Google Analytics API Secret. The API secret can be generated via Google Analytics UI. Required when using the default measurement URL.
+* api_secret: The Google Analytics API Secret. The API secret can be generated via Google Analytics UI. Required when using the default measurement URL. If included, it will be added as a query parameter.
 * measurement_id: The property to be measured's Google Analytics measurement ID. Can be found via Google Analytics UI. Required when using the default measurement URL.
 * measurement_url: URL endpoint to send events to. Defaults to Google Analytics collection endpoint. Optional. If overriden, the user will need to ensure the URL forwards events to Google Analytics.
 * client_id_expires: Time in seconds to store the client ID in long term storage. Defaults to two years. Optional.

--- a/README.md
+++ b/README.md
@@ -50,13 +50,14 @@ in order to catch users who leave immediately after loading the page, then immed
 <script>
   window.dataLayer = window.dataLayer || [];
   function measure(){dataLayer.push(arguments);}
-  // One or more config commands. To send data to google analytics while 
+  // One or more config commands. To send data to google analytics while
   // using cookies for storage:
-  measure('config', 'googleAnalytics', {}, 'cookies', {});
+  measure('config', 'googleAnalytics', {
+    'measurement_id': YOUR_MEASUREMENT_ID,
+    'api_secret': YOUR_API_SECRET,
+  }, 'cookies', {});
 </script>
 ```
-
-[//]: # (TODO kj: Make the config command use the right settings for google analytics)
 
 As an alternative, you can use the development version when testing your page. The dev version has a bigger file size,
 but reports possible errors to the console.
@@ -97,8 +98,107 @@ measure('config', 'eventProcessorName', {}, 'cookies', {expires: 22});
 ```
 
 # Event Processors
+Events are processed with event options arguments. These can
+
 ## Google Analytics
- [//]: # (TODO: kj)
+To configure the Google Analytics event processor, constructor arguments can be passed in via the [code snippet](#installation).
+
+The supported constructor arguments are:
+* api_secret: The Google Analytics API Secret. The API secret can be generated via Google Analytics UI. Required when using the default measurement URL.
+* measurement_id: The property to be measured's Google Analytics measurement ID. Can be found via Google Analytics UI. Required when using the default measurement URL.
+* measurement_url: URL endpoint to send events to. Defaults to Google Analytics collection endpoint. Optional. If overriden, the user will need to ensure the URL forwards events to Google Analytics.
+* client_id_expires: Time in seconds to store the client ID in long term storage. Defaults to two years. Optional.
+* automatic_params: Array of event parameters that will be searched for in the global data model and pulled into all events if found. Optional.
+
+A basic example:
+
+```js
+measure(
+  'config',
+  'googleAnalytics',
+  {
+    'measurement_id': YOUR_MEASUREMENT_ID,
+    'api_secret': YOUR_API_SECRET,
+  },
+  'cookies',
+  {}
+);
+```
+
+Events are processed and sent to Google Analytics using the [event command](#event-command).
+
+For a simple page view event with some supporting data, the user could call:
+
+```js
+measure('event', 'page_view', {
+  'page_title': 'Example Title',
+  'page_path': '/example',
+});
+```
+
+This will send a page_view event to Google Analytics with the event parameters provided. In addition
+to the event level parameters provided, the user can set event parameters using the [set command](#set-command) that will
+then be included in the event sent to Google Analytics even if not explicitly provided in the event command.
+
+To do this for all Google Analytics event processors, an example would be:
+
+```js
+measure('set', 'googleAnalytics', {
+  'currency': 'USD',
+});
+```
+
+All future event calls will now send the currency event parameter with the value USD. This behavior can be overriden
+at the event level as more specific parameters take priority. For instance, the following event sets currency
+to CAD instead of the previously set USD.
+
+```js
+measure('event', 'purchase', {
+  'value' 99,
+  'currency': 'CAD',
+});
+```
+
+In addition to this, the global data model can be used to share event parameters. The global data model contains all the
+key value pairs stored with the [set command](#set-command) when called without relation to a storage or event processor.
+
+```js
+measure('set', 'example_param', 'example_value');
+```
+
+If you would like to retrieve and send this parameter with all Google Analytics events after setting it,
+you would configure your code snippet to look like the following:
+
+```js
+measure(
+  'config',
+  'googleAnalytics',
+  {
+    'measurement_id': YOUR_MEASUREMENT_ID,
+    'api_secret': YOUR_API_SECRET,
+    'automatic_params': ['example_param'],
+  },
+  'cookies',
+  {}
+);
+```
+
+Client ID is a parameter that is stored globally and included in the automatic parameters list by default. The event
+processor generates a new client ID when one is not found in the long term storage and persists this client ID so
+that each event can be tied to a specific client. By default the client ID will be generated and stored for two years,
+though this can be changed via the client_id_expires constructor argument.
+
+We encourage users to let the event processor generate client IDs instead of providing them themselves. If you wish
+to track your users, the userId global key is also a global automatic parameter that users can utilize to track their users.
+
+To do so, just set the user ID:
+```js
+measure('set', 'userId', 'YOUR_USER_ID');
+```
+
+The other automatic parameters that are searched for and can be set globally are: page_path, page_location, and page_title.
+Global parameters are considered as being the least specific and will be overriden by parameters of the same name that are set
+at the `googleAnalytics` level or sent at event command level.
 
 ## Custom Event Processor
 If none of the built-in processors fit your needs, you can create your own event processor.


### PR DESCRIPTION
Built off of https://github.com/googleinterns/measurement-library/pull/67
 An update to the README that explains how the google analytics event processor works.